### PR TITLE
Deprecate the included ide! macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ fn add5<T: Into<u32>>(component: T) -> u32 {
 mod tests {
     use super::*;
     use yare::parameterized;
-
-    ide!();
     
     #[parameterized(
         zero_plus_five = { 0, 5 },
@@ -94,50 +92,6 @@ the following snippet at the top of your crate root:
 #[macro_use]
 extern crate yare;
 ```
-
-### IDE 'run test' intent
-
-IntelliJ IDEA recognizes test cases and provides context menus which allow you to run tests within a certain scope
-(such as a module or a single test case). For example, in IntelliJ you can usually run individual test cases by clicking
-the ▶ icon in the gutter. Unfortunately, attribute macros are currently not expanded by `intellij-rust`.
-This means that the IDE will not recognize test cases generated as a result of attribute macros (such as the
-`yare` macro published by this crate). 
-
-A workaround can be found below (if you have a better solution, please feel free to open an issue; thank you in advance!)
-
-```rust
-fn squared(input: i8) -> i8 {
-  input * input  
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use yare::parameterized as pm;
-    use yare::ide;
-        
-    mod squared_tests { // <--
-        use super::*;
-
-        ide!(); // <--
-    
-        #[pm(
-            two_squared = {2, 4}
-        )]
-        fn test_squared(input: i8, output: i8) {
-            assert_eq!(squared(input), output);
-        }
-    }
-}
-```
-
-Here we created an empty test case (using the `ide!()` macro) which will mark the surrounding module as 'containing test cases'. In
-the gutter you will find the ▶ icon next to the module. This allows you to run test cases per module.
-
-Note: `intellij-rust` does expand declarative macro's (with the new macro engine which can be
-selected in the 'settings' menu), such as this `ide!` macro.
-
 
 ### License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ pub use yare::parameterized;
 /// Using the intellij-rust new macro expansion engine, if this macro is called within a module,
 /// the module will be marked as test, and the 'run as test' context menu will be provided in the
 /// gutter.
+#[doc(hidden)]
+#[deprecated]
 #[macro_export]
 macro_rules! ide {
     () => {
@@ -37,8 +39,6 @@ mod tests {
     mod readme_test {
         use super::*;
 
-        ide!();
-
         #[pm(zero = {
             0, 5
         }, one = {
@@ -54,8 +54,6 @@ mod tests {
     mod marked_as_test_module {
         use super::*;
 
-        ide!();
-
         #[pm(two = { 2, 4 }, six = { 6, 12 }, eight = { 8, 16 })]
         fn test_times2(input: i32, output: i32) {
             let times2 = |receiver: i32| receiver * 2;
@@ -66,8 +64,6 @@ mod tests {
 
     mod transitive_attrs {
         use super::*;
-
-        ide!();
 
         #[pm(none = { None })]
         #[should_panic]


### PR DESCRIPTION
While this macro is still useful, this crate is not the best place for it to exist, as the macro itself is not closely related with the context of this crate.